### PR TITLE
追加: 昆虫詳細API実装（Issue #6）

### DIFF
--- a/internal/controllers/insect_controller.go
+++ b/internal/controllers/insect_controller.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
 
@@ -47,6 +48,14 @@ func (c *InsectController) GetInsectByID(ctx *gin.Context) {
 	}
 	insect, err := c.service.GetInsectByID(ctx.Request.Context(), uint(id))
 	if err != nil {
+		if errors.Is(err, services.ErrNotFound) {
+			ctx.JSON(http.StatusNotFound, dtos.ErrorResponse{
+				Error: dtos.ErrorDetail{
+					Message: "insect not found",
+				},
+			})
+			return
+		}
 		ctx.JSON(http.StatusInternalServerError, dtos.ErrorResponse{
 			Error: dtos.ErrorDetail{
 				Message: "internal server error",

--- a/internal/services/insect_service.go
+++ b/internal/services/insect_service.go
@@ -2,12 +2,16 @@ package services
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/Masaaki618/insectfood-backend/internal/dtos"
 	"github.com/Masaaki618/insectfood-backend/internal/infrastructure/ai"
 	"github.com/Masaaki618/insectfood-backend/internal/repositories"
+	"gorm.io/gorm"
 )
+
+var ErrNotFound = errors.New("not found")
 
 type insectService struct {
 	repository repositories.IInsectRepository
@@ -45,6 +49,9 @@ func (s *insectService) GetInsects(ctx context.Context) ([]dtos.InsectResponse, 
 func (s *insectService) GetInsectByID(ctx context.Context, insectID uint) (*dtos.InsectDetailResponse, error) {
 	insect, err := s.repository.GetInsectByID(ctx, insectID)
 	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrNotFound
+		}
 		return nil, fmt.Errorf("InsectService.GetInsectByID: %w", err)
 	}
 
@@ -74,7 +81,7 @@ func (s *insectService) GetInsectByID(ctx context.Context, insectID uint) (*dtos
 
 	aiComment, err := s.claude.GenerateInsectComment(ctx, insect)
 	if err != nil {
-		return nil, fmt.Errorf("InsectService.GenerateInsectComment: %w", err)
+		aiComment = fmt.Sprintf("まずは%sから始めてみましょう！", insect.Name)
 	}
 	var response dtos.InsectDetailResponse
 	response.InsectResponse = insectRes

--- a/internal/services/insect_service_test.go
+++ b/internal/services/insect_service_test.go
@@ -2,6 +2,7 @@ package services_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -78,12 +79,12 @@ var _ = Describe("InsectService", func() {
 				Model: gorm.Model{ID: 1},
 				Name:  "コオロギ", Difficulty: 1,
 			}
-			mockRepo.EXPECT().GetInsectByID(ctx, insect.ID).Return(&insect, nil)
-			mockRepo.EXPECT().GetRadarChartByInsectID(ctx, uint(1)).Return(nil, nil)
 		})
 
 		Context("DBに昆虫が存在する場合", func() {
 			It("昆虫詳細のDTOを返す", func() {
+				mockRepo.EXPECT().GetInsectByID(ctx, insect.ID).Return(&insect, nil)
+				mockRepo.EXPECT().GetRadarChartByInsectID(ctx, uint(1)).Return(nil, nil)
 				mockClaude.EXPECT().GenerateInsectComment(ctx, &insect).Return("テストコメント", nil)
 
 				result, err := svc.GetInsectByID(ctx, 1)
@@ -94,13 +95,24 @@ var _ = Describe("InsectService", func() {
 			})
 		})
 
-		Context("Claude APIが3回失敗した場合", func() {
-			It("エラーを返す", func() {
+		Context("DBに昆虫が存在しない場合", func() {
+			It("404エラーを返す", func() {
+				mockRepo.EXPECT().GetInsectByID(ctx, uint(2)).Return(nil, gorm.ErrRecordNotFound)
+				result, err := svc.GetInsectByID(ctx, 2)
+				Expect(errors.Is(err, services.ErrNotFound)).To(BeTrue())
+				Expect(result).To(BeNil())
+			})
+		})
+
+		Context("Claude APIが失敗した場合", func() {
+			It("デフォルトコメントを返す", func() {
+				mockRepo.EXPECT().GetInsectByID(ctx, insect.ID).Return(&insect, nil)
+				mockRepo.EXPECT().GetRadarChartByInsectID(ctx, uint(1)).Return(nil, nil)
 				mockClaude.EXPECT().GenerateInsectComment(ctx, &insect).Return("", fmt.Errorf("api error"))
 				result, err := svc.GetInsectByID(ctx, 1)
 
-				Expect(err).To(HaveOccurred())
-				Expect(result).To(BeNil())
+				Expect(err).To(BeNil())
+				Expect(result.AIComment).To(Equal(fmt.Sprintf("まずは%sから始めてみましょう！", insect.Name)))
 			})
 		})
 	})


### PR DESCRIPTION
## 概要

昆虫詳細API（`GET /api/v1/insects/:id`）にTDDで404エラーハンドリングとClaude APIエラー時のデフォルトコメントを実装した。

## 関連 Issue

Closes #6

## 変更の種類

- [x] 新機能（`追加`）
- [ ] バグ修正（`修正`）
- [ ] 既存機能の改善（`更新`）
- [ ] リファクタリング（動作変更なし）
- [ ] ドキュメント
- [x] テスト

## 変更内容の詳細

- `insect_service.go`: `ErrNotFound` を定義し `gorm.ErrRecordNotFound` を変換。Claude APIエラー時に昆虫名を使ったデフォルトコメントを返す
- `insect_controller.go`: `services.ErrNotFound` のとき `404` を返す
- `insect_service_test.go`: 存在しないIDで `ErrNotFound` が返ること・Claude APIエラー時にデフォルトコメントが返ることをテスト

## 動作確認

- [x] `go build ./...` が通る
- [x] `go vet ./...` でエラーがない
- [x] 該当のAPIエンドポイントを curl で叩いて期待通りのレスポンスが返る
- [ ] DBマイグレーションがある場合は `make migrate-up` が成功する

## レビュアーへのメモ

- Controllerは `gorm.ErrRecordNotFound` を直接判定せず `services.ErrNotFound` で判定することで責務を分離している
- デフォルトコメントは固定文字列ではなく昆虫名を使って生成している