### PR TITLE
追加: 診断質問取得API実装（Issue #7）

### DIFF
--- a/internal/services/question_service.go
+++ b/internal/services/question_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/Masaaki618/insectfood-backend/internal/dtos"
@@ -9,7 +10,8 @@ import (
 	"github.com/Masaaki618/insectfood-backend/internal/repositories"
 )
 
-const questionsPerCategory = 2 // パッケージ内のみ使用
+const QuestionsPerCategory = 2 // パッケージ内のみ使用
+var ErrInsufficientQuestions = errors.New("insufficient questions")
 
 type questionService struct {
 	repository repositories.IQuestionRepository
@@ -23,9 +25,12 @@ func NewQuestionService(repository repositories.IQuestionRepository) IQuestionSe
 // GetQuestions はカテゴリ別にランダムで6問取得しDTOに詰め替えて返す
 func (s *questionService) GetQuestions(ctx context.Context) ([]dtos.QuestionResponse, error) {
 	var questionsRes []dtos.QuestionResponse
-	visualQuestions, err := s.repository.GetRandomQuestionsByCategory(ctx, models.CategoryVisual, questionsPerCategory)
+	visualQuestions, err := s.repository.GetRandomQuestionsByCategory(ctx, models.CategoryVisual, QuestionsPerCategory)
 	if err != nil {
 		return nil, fmt.Errorf("QuestionService.GetQuestions visual: %w", err)
+	}
+	if len(visualQuestions) < QuestionsPerCategory {
+		return nil, ErrInsufficientQuestions
 	}
 
 	for _, visualQuestion := range visualQuestions {
@@ -36,9 +41,12 @@ func (s *questionService) GetQuestions(ctx context.Context) ([]dtos.QuestionResp
 		})
 	}
 
-	physicalQuestions, err := s.repository.GetRandomQuestionsByCategory(ctx, models.CategoryPhysical, questionsPerCategory)
+	physicalQuestions, err := s.repository.GetRandomQuestionsByCategory(ctx, models.CategoryPhysical, QuestionsPerCategory)
 	if err != nil {
 		return nil, fmt.Errorf("QuestionService.GetQuestions physical: %w", err)
+	}
+	if len(physicalQuestions) < QuestionsPerCategory {
+		return nil, ErrInsufficientQuestions
 	}
 
 	for _, physicalQuestion := range physicalQuestions {
@@ -48,10 +56,14 @@ func (s *questionService) GetQuestions(ctx context.Context) ([]dtos.QuestionResp
 			Category: string(physicalQuestion.Category),
 		})
 	}
-	mentalQuestions, err := s.repository.GetRandomQuestionsByCategory(ctx, models.CategoryMental, questionsPerCategory)
+	mentalQuestions, err := s.repository.GetRandomQuestionsByCategory(ctx, models.CategoryMental, QuestionsPerCategory)
 	if err != nil {
 		return nil, fmt.Errorf("QuestionService.GetQuestions mental: %w", err)
 	}
+	if len(mentalQuestions) < QuestionsPerCategory {
+		return nil, ErrInsufficientQuestions
+	}
+
 	for _, mentalQuestion := range mentalQuestions {
 		questionsRes = append(questionsRes, dtos.QuestionResponse{
 			ID:       mentalQuestion.ID,

--- a/internal/services/question_service_test.go
+++ b/internal/services/question_service_test.go
@@ -2,6 +2,7 @@ package services_test
 
 import (
 	"context"
+	"errors"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -34,7 +35,7 @@ var _ = Describe("QuestionService", func() {
 	Describe("GetQuestions", func() {
 		Context("全カテゴリのデータが存在する場合", func() {
 			It("3カテゴリ合計6件の質問を返す", func() {
-				mockRepo.EXPECT().GetRandomQuestionsByCategory(ctx, models.CategoryVisual, 2).Return([]models.Question{
+				mockRepo.EXPECT().GetRandomQuestionsByCategory(ctx, models.CategoryVisual, services.QuestionsPerCategory).Return([]models.Question{
 					{
 						Body:     "visual",
 						Category: models.CategoryVisual,
@@ -44,7 +45,7 @@ var _ = Describe("QuestionService", func() {
 						Category: models.CategoryVisual,
 					},
 				}, nil)
-				mockRepo.EXPECT().GetRandomQuestionsByCategory(ctx, models.CategoryPhysical, 2).Return([]models.Question{
+				mockRepo.EXPECT().GetRandomQuestionsByCategory(ctx, models.CategoryPhysical, services.QuestionsPerCategory).Return([]models.Question{
 					{
 						Body:     "physical",
 						Category: models.CategoryPhysical,
@@ -54,7 +55,7 @@ var _ = Describe("QuestionService", func() {
 						Category: models.CategoryPhysical,
 					},
 				}, nil)
-				mockRepo.EXPECT().GetRandomQuestionsByCategory(ctx, models.CategoryMental, 2).Return([]models.Question{
+				mockRepo.EXPECT().GetRandomQuestionsByCategory(ctx, models.CategoryMental, services.QuestionsPerCategory).Return([]models.Question{
 					{
 						Body:     "mental",
 						Category: models.CategoryMental,
@@ -71,6 +72,20 @@ var _ = Describe("QuestionService", func() {
 				Expect(result[0].Category).To(Equal("visual"))
 				Expect(result[2].Category).To(Equal("physical"))
 				Expect(result[4].Category).To(Equal("mental")) //nolint:typecheck
+			})
+
+			It("質問数が2問未満の場合エラーを返す", func() {
+				mockRepo.EXPECT().GetRandomQuestionsByCategory(ctx, models.CategoryVisual, services.QuestionsPerCategory).Return([]models.Question{
+					{
+						Body:     "visual",
+						Category: models.CategoryVisual,
+					},
+				}, nil)
+
+				result, err := svc.GetQuestions(ctx)
+
+				Expect(errors.Is(err, services.ErrInsufficientQuestions)).To(BeTrue())
+				Expect(result).To(BeNil())
 			})
 		})
 	})


### PR DESCRIPTION
## 概要

診断質問取得API（`GET /api/v1/questions`）にTDDで質問数不足時のエラーハンドリングを追加した。

## 関連 Issue

Closes #7

## 変更の種類

- [x] 新機能（`追加`）
- [ ] バグ修正（`修正`）
- [ ] 既存機能の改善（`更新`）
- [ ] リファクタリング（動作変更なし）
- [ ] ドキュメント
- [x] テスト

## 変更内容の詳細

- `question_service.go`: `ErrInsufficientQuestions` を定義し、各カテゴリの質問数が2問未満の場合にエラーを返す
- `question_service_test.go`: 質問数が2問未満の場合に `ErrInsufficientQuestions` が返ることをテスト

## 動作確認

- [x] `go build ./...` が通る
- [x] `go vet ./...` でエラーがない
- [x] 該当のAPIエンドポイントを curl で叩いて期待通りのレスポンスが返る
- [ ] DBマイグレーションがある場合は `make migrate-up` が成功する

## レビュアーへのメモ

- ランダム性はRepository層の `GetRandomQuestionsByCategory` に委譲しているため、Service層のテストでは対応済みとしている