### PR TITLE
診断API（POST /api/v1/diagnosis）をTDDで実装

### DIFF
--- a/internal/services/diagnosis_service.go
+++ b/internal/services/diagnosis_service.go
@@ -35,7 +35,7 @@ func (s *diagnosisService) Diagnose(ctx context.Context, req dtos.DiagnosisReque
 	)
 
 	if err != nil {
-		return nil, fmt.Errorf("diagnosisService.Diagnose: %w", err)
+		aiComment = fmt.Sprintf("まずは%sから始めてみよう!", insects[0].Name)
 	}
 
 	var insectRes dtos.InsectResponse

--- a/internal/services/diagnosis_service_test.go
+++ b/internal/services/diagnosis_service_test.go
@@ -1,0 +1,90 @@
+package services_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Masaaki618/insectfood-backend/internal/dtos"
+	aimock "github.com/Masaaki618/insectfood-backend/internal/infrastructure/ai/mock"
+	"github.com/Masaaki618/insectfood-backend/internal/models"
+	"github.com/Masaaki618/insectfood-backend/internal/repositories/mock"
+	"github.com/Masaaki618/insectfood-backend/internal/services"
+	. "github.com/onsi/ginkgo/v2"
+	"go.uber.org/mock/gomock"
+	"gorm.io/gorm"
+
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("DiagnosisService", func() {
+	var (
+		ctrl       *gomock.Controller
+		mockRepo   *mock.MockIInsectRepository
+		mockClaude *aimock.MockIClaudeClient
+		svc        services.IDiagnosisService
+		ctx        context.Context
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockRepo = mock.NewMockIInsectRepository(ctrl)
+		mockClaude = aimock.NewMockIClaudeClient(ctrl)
+		svc = services.NewDiagnosisService(mockRepo, mockClaude)
+		ctx = context.Background()
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Describe("Diagnose", func() {
+		var insects []models.Insect
+		var req dtos.DiagnosisRequest
+		BeforeEach(func() {
+			insects = []models.Insect{
+				{Model: gorm.Model{ID: 1}, Name: "コオロギ"},
+				{Model: gorm.Model{ID: 2}, Name: "ミールワーム"},
+			}
+
+			req = dtos.DiagnosisRequest{
+				Scores: dtos.DiagnosisScores{
+					Visual:   2,
+					Physical: 0,
+					Mental:   2,
+				},
+			}
+		})
+		Context("正常系", func() {
+			It("診断結果のDTOを返す", func() {
+				mockRepo.EXPECT().GetInsects(ctx).Return(insects, nil)
+				mockClaude.EXPECT().GenerateDiagnosisResult(ctx, req.Scores.Visual, req.Scores.Physical, req.Scores.Mental, insects).Return(uint(1), "コメント", nil)
+
+				res, err := svc.Diagnose(ctx, req)
+				Expect(err).To(BeNil())
+				Expect(res.AIComment).To(Equal("コメント"))
+				Expect(res.Insect.Name).To(Equal("コオロギ"))
+
+			})
+		})
+
+		Context("Claude APIが失敗した場合", func() {
+			It("デフォルトの診断結果を返す", func() {
+				mockRepo.EXPECT().GetInsects(ctx).Return(insects, nil)
+				mockClaude.EXPECT().GenerateDiagnosisResult(ctx, req.Scores.Visual, req.Scores.Physical, req.Scores.Mental, insects).Return(uint(0), "", fmt.Errorf("GenerateDiagnosisResult JSONパース失敗"))
+
+				res, err := svc.Diagnose(ctx, req)
+				Expect(err).To(BeNil())
+				Expect(res.AIComment).To(Equal(fmt.Sprintf("まずは%sから始めてみよう!", insects[0].Name)))
+			})
+		})
+
+		Context("DBエラーが発生した時に", func() {
+			It("エラーを返す", func() {
+				mockRepo.EXPECT().GetInsects(ctx).Return(insects, fmt.Errorf("db error"))
+				res, err := svc.Diagnose(ctx, req)
+				Expect(err.Error()).To(ContainSubstring("diagnosisService.Diagnose"))
+				Expect(res).To(BeNil())
+			})
+		})
+	})
+})

--- a/internal/services/diagnosis_service_test.go
+++ b/internal/services/diagnosis_service_test.go
@@ -55,7 +55,7 @@ var _ = Describe("DiagnosisService", func() {
 			}
 		})
 		Context("正常系", func() {
-			It("診断結果のDTOを返す", func() {
+			It("診断結果のDTOを返すこと", func() {
 				mockRepo.EXPECT().GetInsects(ctx).Return(insects, nil)
 				mockClaude.EXPECT().GenerateDiagnosisResult(ctx, req.Scores.Visual, req.Scores.Physical, req.Scores.Mental, insects).Return(uint(1), "コメント", nil)
 
@@ -68,7 +68,7 @@ var _ = Describe("DiagnosisService", func() {
 		})
 
 		Context("Claude APIが失敗した場合", func() {
-			It("デフォルトの診断結果を返す", func() {
+			It("デフォルトの診断結果を返すこと", func() {
 				mockRepo.EXPECT().GetInsects(ctx).Return(insects, nil)
 				mockClaude.EXPECT().GenerateDiagnosisResult(ctx, req.Scores.Visual, req.Scores.Physical, req.Scores.Mental, insects).Return(uint(0), "", fmt.Errorf("GenerateDiagnosisResult JSONパース失敗"))
 
@@ -79,7 +79,7 @@ var _ = Describe("DiagnosisService", func() {
 		})
 
 		Context("DBエラーが発生した時に", func() {
-			It("エラーを返す", func() {
+			It("エラーを返すこと", func() {
 				mockRepo.EXPECT().GetInsects(ctx).Return(insects, fmt.Errorf("db error"))
 				res, err := svc.Diagnose(ctx, req)
 				Expect(err.Error()).To(ContainSubstring("diagnosisService.Diagnose"))

--- a/internal/services/insect_service_test.go
+++ b/internal/services/insect_service_test.go
@@ -39,7 +39,7 @@ var _ = Describe("InsectService", func() {
 
 	Describe("GetInsects", func() {
 		Context("DBに昆虫が存在する場合", func() {
-			It("昆虫一覧のDTOを返す", func() {
+			It("昆虫一覧のDTOを返すこと", func() {
 				mockRepo.EXPECT().GetInsects(ctx).Return([]models.Insect{
 					{Name: "コオロギ", Difficulty: 1},
 				}, nil)
@@ -53,7 +53,7 @@ var _ = Describe("InsectService", func() {
 		})
 
 		Context("DBに昆虫が0件の場合", func() {
-			It("空のスライスを返す (エラーにはならない)", func() {
+			It("空のスライスを返すこと（エラーにはならない）", func() {
 				mockRepo.EXPECT().GetInsects(ctx).Return([]models.Insect{}, nil)
 				result, err := svc.GetInsects(ctx)
 				Expect(err).To(BeNil())
@@ -62,7 +62,7 @@ var _ = Describe("InsectService", func() {
 		})
 
 		Context("DBエラーが発生した場合", func() {
-			It("エラーをラップして返す", func() {
+			It("エラーをラップして返すこと", func() {
 				mockRepo.EXPECT().GetInsects(ctx).Return(nil, fmt.Errorf("db error"))
 				result, err := svc.GetInsects(ctx)
 				Expect(err).To(HaveOccurred())
@@ -82,7 +82,7 @@ var _ = Describe("InsectService", func() {
 		})
 
 		Context("DBに昆虫が存在する場合", func() {
-			It("昆虫詳細のDTOを返す", func() {
+			It("昆虫詳細のDTOを返すこと", func() {
 				mockRepo.EXPECT().GetInsectByID(ctx, insect.ID).Return(&insect, nil)
 				mockRepo.EXPECT().GetRadarChartByInsectID(ctx, uint(1)).Return(nil, nil)
 				mockClaude.EXPECT().GenerateInsectComment(ctx, &insect).Return("テストコメント", nil)
@@ -96,7 +96,7 @@ var _ = Describe("InsectService", func() {
 		})
 
 		Context("DBに昆虫が存在しない場合", func() {
-			It("404エラーを返す", func() {
+			It("404エラーを返すこと", func() {
 				mockRepo.EXPECT().GetInsectByID(ctx, uint(2)).Return(nil, gorm.ErrRecordNotFound)
 				result, err := svc.GetInsectByID(ctx, 2)
 				Expect(errors.Is(err, services.ErrNotFound)).To(BeTrue())
@@ -105,7 +105,7 @@ var _ = Describe("InsectService", func() {
 		})
 
 		Context("Claude APIが失敗した場合", func() {
-			It("デフォルトコメントを返す", func() {
+			It("デフォルトコメントを返すこと", func() {
 				mockRepo.EXPECT().GetInsectByID(ctx, insect.ID).Return(&insect, nil)
 				mockRepo.EXPECT().GetRadarChartByInsectID(ctx, uint(1)).Return(nil, nil)
 				mockClaude.EXPECT().GenerateInsectComment(ctx, &insect).Return("", fmt.Errorf("api error"))

--- a/internal/services/question_service_test.go
+++ b/internal/services/question_service_test.go
@@ -34,7 +34,7 @@ var _ = Describe("QuestionService", func() {
 
 	Describe("GetQuestions", func() {
 		Context("全カテゴリのデータが存在する場合", func() {
-			It("3カテゴリ合計6件の質問を返す", func() {
+			It("3カテゴリ合計6件の質問を返すこと", func() {
 				mockRepo.EXPECT().GetRandomQuestionsByCategory(ctx, models.CategoryVisual, services.QuestionsPerCategory).Return([]models.Question{
 					{
 						Body:     "visual",
@@ -74,7 +74,7 @@ var _ = Describe("QuestionService", func() {
 				Expect(result[4].Category).To(Equal("mental")) //nolint:typecheck
 			})
 
-			It("質問数が2問未満の場合エラーを返す", func() {
+			It("質問数が2問未満の場合エラーを返すこと", func() {
 				mockRepo.EXPECT().GetRandomQuestionsByCategory(ctx, models.CategoryVisual, services.QuestionsPerCategory).Return([]models.Question{
 					{
 						Body:     "visual",


### PR DESCRIPTION
## 概要

TDDで診断API（POST /api/v1/diagnosis）を実装した。サービス層のテストを先に書き（Red）、その後実装（Green）の順で進めた。

## 関連 Issue

Closes #8

## 変更の種類

- [x] 新機能（`追加`）
- [x] テスト

## 変更内容の詳細

- `internal/services/diagnosis_service_test.go` を追加（正常系・Claude APIエラー・DBエラーの3ケース）
- `internal/services/diagnosis_service.go` にClaude API呼び出し・デフォルトコメント処理を実装

## 動作確認

- [ ] `go build ./...` が通る
- [ ] `go vet ./...` でエラーがない
- [ ] 該当のAPIエンドポイントを curl / HTTPクライアントで叩いて期待通りのレスポンスが返る
- [ ] DBマイグレーションがある場合は `make migrate-up` が成功する

## レビュアーへのメモ

- スコアの範囲外バリデーション（0〜2）はDTOの `validate:"max=2"` タグとGinの `ShouldBind` で対応
- Claude APIエラー時は `insects[0].Name` を使ったデフォルトコメントを返す