### PR TITLE
Repository層のユニットテストを実装する

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,8 @@ jobs:
       - name: ginkgoのインストール
         run: go install github.com/onsi/ginkgo/v2/ginkgo@latest
 
-      - name: テスト実行
-        run: ginkgo -r ./internal/...
+      - name: テスト実行（Service層・Controller層）
+        run: ginkgo -r ./internal/services/... ./internal/controllers/...
         env:
           GOTOOLCHAIN: local
           CGO_ENABLED: "0"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: migrate-up migrate-down seed up down logs lint test mock coverage
+.PHONY: migrate-up migrate-down seed up up-mock down logs lint test test-repo mock coverage
 
 # DB接続情報（.envから読み込み）
 include .env
@@ -30,9 +30,14 @@ down:
 logs:
 	docker compose logs -f app
 
-# テスト実行
+# テスト実行（Service層・Controller層）
 test:
-	ginkgo -r ./internal/...
+	ginkgo -r ./internal/services/... ./internal/controllers/...
+
+# Repository層のテスト実行（テスト用DBが必要）
+test-repo:
+	docker compose up -d db-test
+	TEST_DB_HOST=127.0.0.1 TEST_DB_PORT=3307 DB_USER=$(DB_USER) DB_PASSWORD=$(DB_PASSWORD) DB_NAME=$(DB_NAME) ginkgo -r ./internal/repositories/...
 
 # モック自動生成
 mock:

--- a/compose.yml
+++ b/compose.yml
@@ -36,6 +36,22 @@ services:
       timeout: 5s
       retries: 10
 
+  db-test:
+    image: mysql:8.0
+    ports:
+      - "3307:3306"
+    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --default-time-zone=+09:00
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${DB_NAME}
+      MYSQL_USER: ${DB_USER}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
 volumes:
   db_data:
   go_mod_cache:

--- a/internal/repositories/insect_repository_test.go
+++ b/internal/repositories/insect_repository_test.go
@@ -1,0 +1,106 @@
+package repositories_test
+
+import (
+	"context"
+
+	"github.com/Masaaki618/insectfood-backend/internal/models"
+	"github.com/Masaaki618/insectfood-backend/internal/repositories"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gorm.io/gorm"
+)
+
+var _ = Describe("InsectRepository", func() {
+	var (
+		db  *gorm.DB
+		ctx context.Context
+	)
+
+	BeforeEach(func() {
+		var err error
+		db, err = newTestDB()
+		Expect(err).To(BeNil())
+		ctx = context.Background()
+
+		// テストデータを初期化
+		db.Exec("DELETE FROM radar_charts")
+		db.Exec("DELETE FROM insects")
+	})
+
+	Describe("GetInsects", func() {
+		Context("昆虫が存在する場合", func() {
+			It("昆虫一覧を返すこと", func() {
+				db.Create(&models.Insect{Name: "コオロギ", Difficulty: 1, Introduction: "テスト", Taste: "ナッツ", Texture: "サクサク"})
+				db.Create(&models.Insect{Name: "ミールワーム", Difficulty: 1, Introduction: "テスト", Taste: "淡白", Texture: "サクサク"})
+
+				repo := repositories.NewInsectRepository(db)
+				result, err := repo.GetInsects(ctx)
+
+				Expect(err).To(BeNil())
+				Expect(result).To(HaveLen(2))
+			})
+		})
+
+		Context("昆虫が0件の場合", func() {
+			It("空のスライスを返すこと", func() {
+				repo := repositories.NewInsectRepository(db)
+				result, err := repo.GetInsects(ctx)
+
+				Expect(err).To(BeNil())
+				Expect(result).To(BeEmpty())
+			})
+		})
+	})
+
+	Describe("GetInsectByID", func() {
+		Context("昆虫が存在する場合", func() {
+			It("昆虫詳細を返すこと", func() {
+				insect := models.Insect{Name: "コオロギ", Difficulty: 1, Introduction: "テスト", Taste: "ナッツ", Texture: "サクサク"}
+				db.Create(&insect)
+
+				repo := repositories.NewInsectRepository(db)
+				result, err := repo.GetInsectByID(ctx, insect.ID)
+
+				Expect(err).To(BeNil())
+				Expect(result.Name).To(Equal("コオロギ"))
+			})
+		})
+
+		Context("存在しないIDを指定した場合", func() {
+			It("ErrRecordNotFoundを含むエラーを返すこと", func() {
+				repo := repositories.NewInsectRepository(db)
+				result, err := repo.GetInsectByID(ctx, 99999)
+
+				Expect(err).To(HaveOccurred())
+				Expect(result).To(BeNil())
+			})
+		})
+	})
+
+	Describe("GetRadarChartByInsectID", func() {
+		Context("レーダーチャートが存在する場合", func() {
+			It("レーダーチャートを返すこと", func() {
+				insect := models.Insect{Name: "コオロギ", Difficulty: 1, Introduction: "テスト", Taste: "ナッツ", Texture: "サクサク"}
+				db.Create(&insect)
+				db.Create(&models.RadarChart{InsectID: insect.ID, UmamiScore: 3, BitterScore: 1, EguScore: 1, FlavorScore: 4, KimoScore: 1})
+
+				repo := repositories.NewInsectRepository(db)
+				result, err := repo.GetRadarChartByInsectID(ctx, insect.ID)
+
+				Expect(err).To(BeNil())
+				Expect(result).NotTo(BeNil())
+				Expect(result.UmamiScore).To(Equal(uint8(3)))
+			})
+		})
+
+		Context("レーダーチャートが存在しない場合", func() {
+			It("nilを返すこと（エラーにはならない）", func() {
+				repo := repositories.NewInsectRepository(db)
+				result, err := repo.GetRadarChartByInsectID(ctx, 99999)
+
+				Expect(err).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+		})
+	})
+})

--- a/internal/repositories/question_repository_test.go
+++ b/internal/repositories/question_repository_test.go
@@ -1,0 +1,55 @@
+package repositories_test
+
+import (
+	"context"
+
+	"github.com/Masaaki618/insectfood-backend/internal/models"
+	"github.com/Masaaki618/insectfood-backend/internal/repositories"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gorm.io/gorm"
+)
+
+var _ = Describe("QuestionRepository", func() {
+	var (
+		db  *gorm.DB
+		ctx context.Context
+	)
+
+	BeforeEach(func() {
+		var err error
+		db, err = newTestDB()
+		Expect(err).To(BeNil())
+		ctx = context.Background()
+
+		// テストデータを初期化
+		db.Exec("DELETE FROM questions")
+	})
+
+	Describe("GetRandomQuestionsByCategory", func() {
+		Context("質問が存在する場合", func() {
+			It("指定カテゴリの質問をlimit件返すこと", func() {
+				db.Create(&models.Question{Body: "質問1", Category: models.CategoryVisual})
+				db.Create(&models.Question{Body: "質問2", Category: models.CategoryVisual})
+				db.Create(&models.Question{Body: "質問3", Category: models.CategoryVisual})
+
+				repo := repositories.NewQuestionRepository(db)
+				result, err := repo.GetRandomQuestionsByCategory(ctx, models.CategoryVisual, 2)
+
+				Expect(err).To(BeNil())
+				Expect(result).To(HaveLen(2))
+				Expect(result[0].Category).To(Equal(models.CategoryVisual))
+			})
+		})
+
+		Context("指定カテゴリの質問が0件の場合", func() {
+			It("空のスライスを返すこと", func() {
+				repo := repositories.NewQuestionRepository(db)
+				result, err := repo.GetRandomQuestionsByCategory(ctx, models.CategoryVisual, 2)
+
+				Expect(err).To(BeNil())
+				Expect(result).To(BeEmpty())
+			})
+		})
+	})
+})

--- a/internal/repositories/repositories_suite_test.go
+++ b/internal/repositories/repositories_suite_test.go
@@ -1,0 +1,13 @@
+package repositories_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestRepositories(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Repositories Suite")
+}

--- a/internal/repositories/testhelper_test.go
+++ b/internal/repositories/testhelper_test.go
@@ -1,0 +1,41 @@
+package repositories_test
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Masaaki618/insectfood-backend/internal/models"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+)
+
+// newTestDB はテスト用DBに接続してマイグレーションを実行する
+func newTestDB() (*gorm.DB, error) {
+	host := getEnvOrDefault("TEST_DB_HOST", "127.0.0.1")
+	port := getEnvOrDefault("TEST_DB_PORT", "3307")
+	user := getEnvOrDefault("DB_USER", "insectfood")
+	password := getEnvOrDefault("DB_PASSWORD", "")
+	name := getEnvOrDefault("DB_NAME", "insectfood")
+
+	dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?charset=utf8mb4&collation=utf8mb4_unicode_ci&parseTime=True&loc=Asia%%2FTokyo",
+		user, password, host, port, name,
+	)
+	db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{})
+	if err != nil {
+		return nil, fmt.Errorf("newTestDB: %w", err)
+	}
+
+	// テーブルを自動作成
+	if err := db.AutoMigrate(&models.Insect{}, &models.RadarChart{}, &models.Question{}); err != nil {
+		return nil, fmt.Errorf("AutoMigrate: %w", err)
+	}
+
+	return db, nil
+}
+
+func getEnvOrDefault(key, defaultVal string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return defaultVal
+}


### PR DESCRIPTION
## 概要

Repository層のDBアクセスをテスト用DBに対してGinkgoでテストする実装を追加した。テスト用DBは本番DBと分離しポート3307で起動する。

## 関連 Issue

Closes #12

## 変更の種類

- [x] テスト

## 変更内容の詳細

- `compose.yml`: テスト用DB（`db-test`、ポート3307）を追加
- `Makefile`: `make test-repo` コマンドを追加、`make test` をService/Controller層のみに限定
- `internal/repositories/repositories_suite_test.go`: Ginkgoスイートファイルを追加
- `internal/repositories/testhelper_test.go`: テスト用DB接続ヘルパーを追加
- `internal/repositories/insect_repository_test.go`: GetInsects / GetInsectByID / GetRadarChartByInsectID のテストを追加
- `internal/repositories/question_repository_test.go`: GetRandomQuestionsByCategory のテストを追加

## 動作確認

- [ ] `go build ./...` が通る
- [ ] `go vet ./...` でエラーがない
- [ ] 該当のAPIエンドポイントを curl / HTTPクライアントで叩いて期待通りのレスポンスが返る
- [ ] DBマイグレーションがある場合は `make migrate-up` が成功する

## レビュアーへのメモ

- `make test` はService/Controller層のみ（DBなしで実行可能）
- `make test-repo` はテスト用DBを自動起動してRepository層をテスト
- テスト用DBは環境変数 `TEST_DB_HOST=127.0.0.1 TEST_DB_PORT=3307` で切り替え
- 各テストのBeforeEachでテーブルをDELETEしてテストデータを初期化