### PR TITLE
追加: mainマージ時にCloud Runへ自動デプロイするCI/CDを設定

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy to Cloud Run
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: ソースコードをチェックアウト
+        uses: actions/checkout@v4
+
+      - name: GCPに認証
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: gcloudをセットアップ
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: DockerをArtifact Registryに認証
+        run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
+
+      - name: DockerイメージをCloud Buildでビルド＆プッシュ
+        run: |
+          gcloud builds submit \
+            --config cloudbuild.yaml \
+            --project ${{ secrets.GCP_PROJECT_ID }}
+
+      - name: Cloud Runにデプロイ
+        run: |
+          gcloud run deploy insectfood-backend \
+            --image asia-northeast1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/insectfood/backend:latest \
+            --region asia-northeast1 \
+            --platform managed \
+            --allow-unauthenticated \
+            --set-env-vars "SERVER_PORT=8080,DB_HOST=${{ secrets.DB_HOST }},DB_PORT=${{ secrets.DB_PORT }},DB_NAME=${{ secrets.DB_NAME }},DB_USER=${{ secrets.DB_USER }},DB_PASSWORD=${{ secrets.DB_PASSWORD }},DB_TLS=true,ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}" \
+            --project ${{ secrets.GCP_PROJECT_ID }}


### PR DESCRIPTION
## 概要

mainブランチにマージされたタイミングで自動的にCloud RunへデプロイされるGitHub Actionsワークフローを追加した。
これにより、コードをマージするだけで本番環境に反映されるようになる。

## 関連 Issue

Closes #

## 変更の種類

- [x] 新機能（`追加`）

## 変更内容の詳細

- `.github/workflows/deploy.yml`: mainへのpush時に以下を自動実行するワークフローを追加
  1. GCPサービスアカウントで認証
  2. `cloudbuild.yaml` を使ってDockerイメージをビルド＆Artifact Registryにプッシュ
  3. Cloud Runに最新イメージをデプロイ
- GitHub Secretsに以下を登録済み（コード内には機密情報なし）
  - `GCP_SA_KEY`: GCPサービスアカウントキー
  - `GCP_PROJECT_ID`: GCPプロジェクトID
  - `DB_HOST` / `DB_PORT` / `DB_NAME` / `DB_USER` / `DB_PASSWORD`: TiDB Cloud接続情報
  - `ANTHROPIC_API_KEY`: Claude APIキー

## 動作確認

- [x] `go build ./...` が通る
- [x] `go vet ./...` でエラーがない
- [x] ワークフローファイルのYAML構文に問題なし

## レビュアーへのメモ

- このPRをmainにマージするとワークフローが初回実行される
- GCPサービスアカウント `github-actions-deploy` にCloud Run・Artifact Registry・Cloud Buildの権限を付与済み